### PR TITLE
Changed ntv_videojs reference from dot notation to property notation

### DIFF
--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+/* eslint-disable dot-notation */
 /**
  * @file setup.js - Functions for setting up a player without
  * user interaction based on the data-setup `attribute` of the video tag.
@@ -11,7 +12,7 @@ import window from 'global/window';
 
 let _windowLoaded = false;
 
-let ntv_videojs;
+window['ntv_videojs'] = {};
 
 /**
  * Set up any tags that have a data-setup `attribute` when the player is started.
@@ -19,7 +20,7 @@ let ntv_videojs;
 const autoSetup = function() {
 
   // Protect against breakage in non-browser environments and check global autoSetup option.
-  if (!Dom.isReal() || ntv_videojs.options.autoSetup === false) {
+  if (!Dom.isReal() || window['ntv_videojs'].options.autoSetup === false) {
     return;
   }
 
@@ -45,7 +46,7 @@ const autoSetup = function() {
           // We only auto-setup if they've added the data-setup attr.
           if (options !== null) {
             // Create new video.js instance.
-            ntv_videojs(mediaEl);
+            window['ntv_videojs'](mediaEl);
           }
         }
 
@@ -74,7 +75,7 @@ const autoSetup = function() {
  */
 function autoSetupTimeout(wait, vjs) {
   if (vjs) {
-    ntv_videojs = vjs;
+    window['ntv_videojs'] = vjs;
   }
 
   window.setTimeout(autoSetup, wait);

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+/* eslint-disable dot-notation */
 /**
  * @file tech.js
  */
@@ -969,9 +970,9 @@ class Tech extends Component {
 
     name = toTitleCase(name);
 
-    if (window && window.ntv_videojs && window.ntv_videojs[name]) {
+    if (window && window['ntv_videojs'] && window['ntv_videojs'][name]) {
       log.warn(`The ${name} tech was added to the videojs object when it should be registered using videojs.registerTech(name, tech)`);
-      return window.ntv_videojs[name];
+      return window.window['ntv_videojs'][name];
     }
   }
 }

--- a/test/api/api.js
+++ b/test/api/api.js
@@ -1,16 +1,17 @@
 /* eslint-env qunit */
 /* eslint-disable camelcase */
+/* eslint-disable dot-notation */
 /**
  * These tests run on the minified, window.ntv_videojs and ensure the needed
  * APIs still exist
  */
 import document from 'global/document';
 import window from 'global/window';
-const videojs = window.ntv_videojs;
+const videojs = window['ntv_videojs'];
 
 QUnit.module('Player API');
 QUnit.test('videojs should exist on the window', function(assert) {
-  assert.ok(window.ntv_videojs, 'videojs exists on the window');
+  assert.ok(window['ntv_videojs'], 'videojs exists on the window');
 });
 
 QUnit.test('should be able to access expected player API methods', function(assert) {


### PR DESCRIPTION
Changing ntv_videojs to this format makes it available to the adserver client.

